### PR TITLE
validation/tests: ensure minimum size of vm images of 8gb

### DIFF
--- a/validation/tests/utils/remote/create-vm.sh
+++ b/validation/tests/utils/remote/create-vm.sh
@@ -165,9 +165,8 @@ if [[ "$IMAGE_URL" == *.img.xz ]]; then
     else
         wget -q -O "$WORK_DIR/ubuntu-core.img.xz" "$IMAGE_URL"
     fi
-    
+
     unxz "$WORK_DIR/ubuntu-core.img.xz"
-    ensure_vmimage_size "$WORK_DIR/ubuntu-core.img"
 
 elif [[ "$IMAGE_URL" == *.img ]]; then
     if [ -f "$IMAGE_URL" ]; then
@@ -179,6 +178,10 @@ else
     echo "Image extension not supported, exiting..."
     exit 1
 fi
+
+# to support the cdimages we need to ensure they are 
+# expanded, as they come in 4gb flavors.
+ensure_vmimage_size "$WORK_DIR/ubuntu-core.img"
 
 if test "$(lsb_release -cs)" = focal; then
     snap install swtpm-mvo --beta

--- a/validation/tests/utils/remote/create-vm.sh
+++ b/validation/tests/utils/remote/create-vm.sh
@@ -24,7 +24,7 @@ execute_remote(){
 }
 
 wait_for_ssh(){
-    retry=150
+    retry=200
     while ! execute_remote true; do
         retry=$(( retry - 1 ))
         if [ $retry -le 0 ]; then
@@ -147,7 +147,8 @@ ensure_vmimage_size() {
         qemu-img resize "$image_file" 8G
 
         # TODO: workaround in place to ensure that the GPT header is correct
-        # (see PR https://github.com/snapcore/snapd/pull/11394)
+        # (see PR https://github.com/snapcore/snapd/pull/11394), maybe remove this
+        # once this has been merged?
         printf "w\nY\nY\nq\n" | gdisk "$WORK_DIR/ubuntu-core.img"
     fi
 }
@@ -165,9 +166,7 @@ if [[ "$IMAGE_URL" == *.img.xz ]]; then
     else
         wget -q -O "$WORK_DIR/ubuntu-core.img.xz" "$IMAGE_URL"
     fi
-
     unxz "$WORK_DIR/ubuntu-core.img.xz"
-
 elif [[ "$IMAGE_URL" == *.img ]]; then
     if [ -f "$IMAGE_URL" ]; then
         cp "$IMAGE_URL" "$WORK_DIR/ubuntu-core.img"

--- a/validation/tests/utils/remote/create-vm.sh
+++ b/validation/tests/utils/remote/create-vm.sh
@@ -140,7 +140,7 @@ get_qemu_for_nested_vm(){
 ensure_vmimage_size() {
     # set a minimum size of 8gb
     local image_file="$1"
-    local minimum_size=8*1024*1024*1024
+    local minimum_size=$((8*1024*1024*1024))
     local actual_size=$(stat -c %s "$image_file")
     if [ $actual_size -lt $minimum_size ]; then
         echo "Image size is too small, resizing to 8gb"


### PR DESCRIPTION
When doing daily cdimage tests, the images we download are only 4gb in size, which is not enough for the snapd tests to run. This PR automatically extends vm images to 8gb if they are not already 8gb or above.

This PR also increases the number of ssh tries to 200, as it was already dangerously close to 150 tries before succeeding. (It currently uses 125-130/150 tries before it succeeds, not a large margin of error).

